### PR TITLE
Record transaction

### DIFF
--- a/abis/Grant.json
+++ b/abis/Grant.json
@@ -271,9 +271,9 @@
       },
       {
         "indexed": false,
-        "internalType": "bytes32",
+        "internalType": "bytes",
         "name": "transactionHash",
-        "type": "bytes32"
+        "type": "bytes"
       },
       {
         "indexed": false,
@@ -491,9 +491,9 @@
         "type": "uint96"
       },
       {
-        "internalType": "bytes32",
+        "internalType": "bytes",
         "name": "_transactionHash",
-        "type": "bytes32"
+        "type": "bytes"
       },
       {
         "internalType": "uint256",

--- a/abis/Grant.json
+++ b/abis/Grant.json
@@ -214,6 +214,19 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": true,
         "internalType": "address",
         "name": "previousOwner",
@@ -227,6 +240,55 @@
       }
     ],
     "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint96",
+        "name": "applicationId",
+        "type": "uint96"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint96",
+        "name": "milestoneId",
+        "type": "uint96"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "transactionHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "time",
+        "type": "uint256"
+      }
+    ],
+    "name": "TransactionRecord",
     "type": "event"
   },
   {
@@ -414,6 +476,34 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint96",
+        "name": "_applicationId",
+        "type": "uint96"
+      },
+      {
+        "internalType": "uint96",
+        "name": "_milestoneId",
+        "type": "uint96"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_transactionHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "recordTransaction",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/contracts/Grant.sol
+++ b/contracts/Grant.sol
@@ -62,7 +62,6 @@ contract Grant is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     event TransactionRecord(
         uint96 indexed applicationId,
         uint96 milestoneId,
-        address asset,
         address sender,
         bytes transactionHash,
         uint256 amount,
@@ -218,5 +217,6 @@ contract Grant is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         uint256 _amount
     ) external onlyWorkspaceAdmin {
         // TODO
+        emit TransactionRecord(_applicationId, _milestoneId, msg.sender, _transactionHash, _amount, block.timestamp);
     }
 }

--- a/contracts/Grant.sol
+++ b/contracts/Grant.sol
@@ -58,6 +58,17 @@ contract Grant is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         uint256 time
     );
 
+    /// @notice Emitted when a transaction is simply recorded
+    event TransactionRecord(
+        uint96 indexed applicationId,
+        uint96 milestoneId,
+        address asset,
+        address sender,
+        bytes32 transactionHash,
+        uint256 amount,
+        uint256 time
+    );
+
     modifier onlyWorkspaceAdmin() {
         require(workspaceReg.isWorkspaceAdmin(workspaceId, msg.sender), "Unauthorised: Not an admin");
         _;
@@ -198,5 +209,14 @@ contract Grant is Initializable, UUPSUpgradeable, OwnableUpgradeable {
             _erc20Interface.transferFrom(msg.sender, applicationReg.getApplicationOwner(_applicationId), _amount),
             "Failed to transfer funds"
         );
+    }
+
+    function recordTransaction(
+        uint96 _applicationId,
+        uint96 _milestoneId,
+        bytes32 _transactionHash,
+        uint256 _amount
+    ) external onlyWorkspaceAdmin {
+        // TODO
     }
 }

--- a/contracts/Grant.sol
+++ b/contracts/Grant.sol
@@ -216,7 +216,6 @@ contract Grant is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         bytes memory _transactionHash,
         uint256 _amount
     ) external onlyWorkspaceAdmin {
-        // TODO
         emit TransactionRecord(_applicationId, _milestoneId, msg.sender, _transactionHash, _amount, block.timestamp);
     }
 }

--- a/contracts/Grant.sol
+++ b/contracts/Grant.sol
@@ -64,7 +64,7 @@ contract Grant is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         uint96 milestoneId,
         address asset,
         address sender,
-        bytes32 transactionHash,
+        bytes transactionHash,
         uint256 amount,
         uint256 time
     );
@@ -214,7 +214,7 @@ contract Grant is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     function recordTransaction(
         uint96 _applicationId,
         uint96 _milestoneId,
-        bytes32 _transactionHash,
+        bytes memory _transactionHash,
         uint256 _amount
     ) external onlyWorkspaceAdmin {
         // TODO

--- a/test/grant/Grant.behavior.ts
+++ b/test/grant/Grant.behavior.ts
@@ -1,5 +1,4 @@
 import { expect } from "chai";
-import { assert } from "console";
 import { ethers, upgrades } from "hardhat";
 
 export function shouldBehaveLikeGrant(): void {

--- a/test/grant/Grant.behavior.ts
+++ b/test/grant/Grant.behavior.ts
@@ -1,9 +1,25 @@
 import { expect } from "chai";
+import { assert } from "console";
 import { ethers, upgrades } from "hardhat";
 
 export function shouldBehaveLikeGrant(): void {
   it("Application count can only be modified by applicationRegistry", async function () {
     expect(this.grant.connect(this.signers.admin).incrementApplicant()).to.be.reverted;
+  });
+
+  describe("Recording a transaction", async function () {
+    it("record transaction successful, initiated by admin", async function () {
+      let tx = await this.grant.connect(this.signers.admin).recordTransaction(0, 0, "0x12", 100);
+      tx = await tx.wait();
+      const { events } = tx;
+      expect(events[0].event).to.equal("TransactionRecord");
+    });
+
+    it("record transaction should not be successful if initiated by non admin", async function () {
+      expect(this.grant.connect(this.signers.nonAdmin).recordTransaction(0, 0, "0x12", 100)).to.revertedWith(
+        "Unauthorised: Not an admin",
+      );
+    });
   });
 
   describe("Updating a grant is", async function () {


### PR DESCRIPTION
This PR adds a function `recordTransaction` to contract `Grant.sol`. This will be useful to emit events when a transaction is initiated and completed outside the Questbook app.