### PR TITLE
Batch applications

### DIFF
--- a/abis/ApplicationRegistry.json
+++ b/abis/ApplicationRegistry.json
@@ -321,6 +321,29 @@
   {
     "inputs": [
       {
+        "internalType": "uint96[]",
+        "name": "_applicationIds",
+        "type": "uint96[]"
+      },
+      {
+        "internalType": "enum ApplicationRegistry.ApplicationState[]",
+        "name": "_applicationStates",
+        "type": "uint8[]"
+      },
+      {
+        "internalType": "uint96",
+        "name": "_workspaceId",
+        "type": "uint96"
+      }
+    ],
+    "name": "batchUpdateApplicationState",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint96",
         "name": "_applicationId",
         "type": "uint96"

--- a/contracts/ApplicationRegistry.sol
+++ b/contracts/ApplicationRegistry.sol
@@ -222,6 +222,12 @@ contract ApplicationRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeab
         );
     }
 
+    /**
+     * @notice Batch update application state
+     * @param _applicationsIds an array of target applicationIds for which state needs to be updated
+     * @param _applicationStates an array of updated states for the applications
+     * @param _workspaceId workspace id of application's grant
+     */
     function batchUpdateApplicationState(
         uint96[] memory _applicationIds,
         ApplicationState[] memory _applicationStates,

--- a/contracts/ApplicationRegistry.sol
+++ b/contracts/ApplicationRegistry.sol
@@ -196,7 +196,7 @@ contract ApplicationRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeab
         uint96 _workspaceId,
         ApplicationState _state,
         string memory _reasonMetadataHash
-    ) external onlyWorkspaceAdmin(_workspaceId) {
+    ) public onlyWorkspaceAdmin(_workspaceId) {
         Application storage application = applications[_applicationId];
         require(application.workspaceId == _workspaceId, "ApplicationStateUpdate: Invalid workspace");
         /// @notice grant creator can only make below transitions
@@ -220,6 +220,20 @@ contract ApplicationRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeab
             application.milestoneCount,
             block.timestamp
         );
+    }
+
+    function batchUpdateApplicationState(
+        uint96[] memory _applicationIds,
+        ApplicationState[] memory _applicationStates,
+        uint96 _workspaceId
+    ) external onlyWorkspaceAdmin(_workspaceId) {
+        require(
+            _applicationIds.length == _applicationStates.length,
+            "applicationIds and applicationStates array length mismatch"
+        );
+        for (uint256 i = 0; i < _applicationIds.length; i++) {
+            updateApplicationState(_applicationIds[i], _workspaceId, _applicationStates[i], " ");
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds function `batchUpdateApplicationState()` to the contract `ApplicationRegistry.sol`. This has been done so that the DAO admin can batch accept/reject the applications.