### PR TITLE
Grantupdate

### DIFF
--- a/.openzeppelin/goerli.json
+++ b/.openzeppelin/goerli.json
@@ -1665,6 +1665,125 @@
           }
         }
       }
+    },
+    "4f140d46584bb9348f7e2e63b05ce15e33cde7013a7d548395dc0fb65663d548": {
+      "address": "0x1f34460bEa9519E3a2F8c25379e0E6BAC6fC426D",
+      "txHash": "0x7d2e42c47cedd3e0577976d03f78a44c9d5633537ba4c475f9127a7012e75c65",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\ERC1967\\ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\UUPSUpgradeable.sol:107"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:87"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:102"
+          },
+          {
+            "label": "applicationReviewReg",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_contract(IApplicationReviewRegistry)6219",
+            "contract": "GrantFactory",
+            "src": "contracts\\GrantFactory.sol:20"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IApplicationReviewRegistry)6219": {
+            "label": "contract IApplicationReviewRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/goerli.json
+++ b/.openzeppelin/goerli.json
@@ -442,7 +442,7 @@
             "slot": "0",
             "type": "t_uint8",
             "contract": "Initializable",
-            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
             "retypedFrom": "bool"
           },
           {
@@ -451,7 +451,7 @@
             "slot": "0",
             "type": "t_bool",
             "contract": "Initializable",
-            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
           },
           {
             "label": "__gap",
@@ -459,7 +459,7 @@
             "slot": "1",
             "type": "t_array(t_uint256)50_storage",
             "contract": "ERC1967UpgradeUpgradeable",
-            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\ERC1967\\ERC1967UpgradeUpgradeable.sol:211"
           },
           {
             "label": "__gap",
@@ -467,7 +467,7 @@
             "slot": "51",
             "type": "t_array(t_uint256)50_storage",
             "contract": "UUPSUpgradeable",
-            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\UUPSUpgradeable.sol:107"
           },
           {
             "label": "__gap",
@@ -475,7 +475,7 @@
             "slot": "101",
             "type": "t_array(t_uint256)50_storage",
             "contract": "ContextUpgradeable",
-            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
           },
           {
             "label": "_owner",
@@ -483,7 +483,7 @@
             "slot": "151",
             "type": "t_address",
             "contract": "OwnableUpgradeable",
-            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
           },
           {
             "label": "__gap",
@@ -491,7 +491,7 @@
             "slot": "152",
             "type": "t_array(t_uint256)49_storage",
             "contract": "OwnableUpgradeable",
-            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:87"
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:87"
           },
           {
             "label": "_paused",
@@ -499,7 +499,7 @@
             "slot": "201",
             "type": "t_bool",
             "contract": "PausableUpgradeable",
-            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
           },
           {
             "label": "__gap",
@@ -507,15 +507,15 @@
             "slot": "202",
             "type": "t_array(t_uint256)49_storage",
             "contract": "PausableUpgradeable",
-            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:102"
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:102"
           },
           {
             "label": "applicationReviewReg",
             "offset": 0,
             "slot": "251",
-            "type": "t_contract(IApplicationReviewRegistry)6099",
+            "type": "t_contract(IApplicationReviewRegistry)6148",
             "contract": "GrantFactory",
-            "src": "contracts/GrantFactory.sol:19"
+            "src": "contracts\\GrantFactory.sol:19"
           }
         ],
         "types": {
@@ -535,7 +535,7 @@
             "label": "bool",
             "numberOfBytes": "1"
           },
-          "t_contract(IApplicationReviewRegistry)6099": {
+          "t_contract(IApplicationReviewRegistry)6148": {
             "label": "contract IApplicationReviewRegistry",
             "numberOfBytes": "20"
           },
@@ -1424,6 +1424,244 @@
           "t_uint96": {
             "label": "uint96",
             "numberOfBytes": "12"
+          }
+        }
+      }
+    },
+    "16fa5c13f864a5e48e49a08eb0cdf9665e885c77b45182e9e25fa29788d66eb0": {
+      "address": "0x3b40F3C11936c5559428384e1441beA0D0683258",
+      "txHash": "0x93f4013a1d4501d1d16ea1e1c6166a40007f71f5dc38fa607047f9a89d7d7432",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\ERC1967\\ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\UUPSUpgradeable.sol:107"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:87"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:102"
+          },
+          {
+            "label": "applicationReviewReg",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_contract(IApplicationReviewRegistry)6199",
+            "contract": "GrantFactory",
+            "src": "contracts\\GrantFactory.sol:20"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IApplicationReviewRegistry)6199": {
+            "label": "contract IApplicationReviewRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "36abefe3a5ee9a926af42f3be1a22449084e74de457867b6dfd89b1b56931b0e": {
+      "address": "0x96d854825678CD02A8eEA22a53Ee6DC6D1aE9722",
+      "txHash": "0x59f0576a5c6e689c4f7b15ee2b099b85536a461dd0c7cf83d83d1e8cf5e1a598",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\ERC1967\\ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\UUPSUpgradeable.sol:107"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:87"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:102"
+          },
+          {
+            "label": "applicationReviewReg",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_contract(IApplicationReviewRegistry)6193",
+            "contract": "GrantFactory",
+            "src": "contracts\\GrantFactory.sol:20"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IApplicationReviewRegistry)6193": {
+            "label": "contract IApplicationReviewRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
           }
         }
       }

--- a/.openzeppelin/goerli.json
+++ b/.openzeppelin/goerli.json
@@ -1784,6 +1784,125 @@
           }
         }
       }
+    },
+    "2ff5772a05da065bad1b1393134fbb51c2f6489475afc6d4a913788894f5c66a": {
+      "address": "0xb8AEd414043d5A48f631658C7D72205F238Fd35F",
+      "txHash": "0x7439b5d4358a1a39ae142792e6debc0d50f76a0c9d572bbd12738a8ea2d960c7",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\ERC1967\\ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\UUPSUpgradeable.sol:107"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:87"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:102"
+          },
+          {
+            "label": "applicationReviewReg",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_contract(IApplicationReviewRegistry)6271",
+            "contract": "GrantFactory",
+            "src": "contracts\\GrantFactory.sol:20"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IApplicationReviewRegistry)6271": {
+            "label": "contract IApplicationReviewRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/abis/Grant.json
+++ b/abis/Grant.json
@@ -393,6 +393,19 @@
   },
   {
     "inputs": [],
+    "name": "grantFactory",
+    "outputs": [
+      {
+        "internalType": "contract IGrantFactory",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "incrementApplicant",
     "outputs": [],
     "stateMutability": "nonpayable",
@@ -418,6 +431,11 @@
       {
         "internalType": "contract IApplicationRegistry",
         "name": "_applicationReg",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IGrantFactory",
+        "name": "_grantFactory",
         "type": "address"
       },
       {

--- a/abis/GrantFactory.json
+++ b/abis/GrantFactory.json
@@ -96,6 +96,43 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": true,
+        "internalType": "address",
+        "name": "grantAddress",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint96",
+        "name": "workspaceId",
+        "type": "uint96"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "metadataHash",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "active",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "time",
+        "type": "uint256"
+      }
+    ],
+    "name": "GrantUpdatedFromFactory",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": false,
         "internalType": "uint8",
         "name": "version",
@@ -317,6 +354,62 @@
   {
     "inputs": [],
     "name": "unpause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "grantAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint96",
+        "name": "_workspaceId",
+        "type": "uint96"
+      },
+      {
+        "internalType": "contract IWorkspaceRegistry",
+        "name": "_workspaceReg",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "_metadataHash",
+        "type": "string"
+      }
+    ],
+    "name": "updateGrant",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "grantAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint96",
+        "name": "_workspaceId",
+        "type": "uint96"
+      },
+      {
+        "internalType": "contract IWorkspaceRegistry",
+        "name": "_workspaceReg",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_canAcceptApplication",
+        "type": "bool"
+      }
+    ],
+    "name": "updateGrantAccessibility",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/contracts/Grant.sol
+++ b/contracts/Grant.sol
@@ -141,7 +141,7 @@ contract Grant is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     }
 
     /**
-     * @notice Update the metadata pointer of a grant, can be called by workspace admins
+     * @notice Update the metadata pointer of a grant, can be called by GrantFactory contract
      * @param _metadataHash New URL that points to grant metadata
      */
     function updateGrant(string memory _metadataHash) external onlyGrantFactory {
@@ -151,7 +151,7 @@ contract Grant is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     }
 
     /**
-     * @notice Update grant accessibility, can be called by workspace admins
+     * @notice Update grant accessibility, can be called by GrantFactory contract
      * @param _canAcceptApplication set to false for disabling grant from receiving new applications
      */
     function updateGrantAccessibility(bool _canAcceptApplication) external onlyGrantFactory {

--- a/contracts/Grant.sol
+++ b/contracts/Grant.sol
@@ -137,7 +137,7 @@ contract Grant is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     function updateGrant(string memory _metadataHash) external onlyWorkspaceAdmin {
         require(numApplicants == 0, "GrantUpdate: Applicants have already started applying");
         metadataHash = _metadataHash;
-        emit GrantUpdated(workspaceId, _metadataHash, active, block.timestamp);
+        // emit GrantUpdated(workspaceId, _metadataHash, active, block.timestamp);
     }
 
     /**

--- a/contracts/Grant.sol
+++ b/contracts/Grant.sol
@@ -146,7 +146,7 @@ contract Grant is Initializable, UUPSUpgradeable, OwnableUpgradeable {
      */
     function updateGrantAccessibility(bool _canAcceptApplication) external onlyWorkspaceAdmin {
         active = _canAcceptApplication;
-        emit GrantUpdated(workspaceId, metadataHash, _canAcceptApplication, block.timestamp);
+        // emit GrantUpdated(workspaceId, metadataHash, _canAcceptApplication, block.timestamp);
     }
 
     /**

--- a/contracts/GrantFactory.sol
+++ b/contracts/GrantFactory.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "./Grant.sol";
 import "./interfaces/IApplicationReviewRegistry.sol";
+import "./interfaces/IGrant.sol";
 
 /// @title Factory contract used to create new grants,
 /// each grant is a new contract deployed using this factory
@@ -23,6 +24,22 @@ contract GrantFactory is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
 
     /// @notice Emitted when a Grant implementation contract is upgraded
     event GrantImplementationUpdated(address grantAddress, bool success, bytes data);
+
+    /// @notice Emitted when a Grant is updated
+    event GrantUpdated(
+        address indexed grantAddress,
+        uint96 indexed workspaceId,
+        string metadataHash,
+        bool active,
+        uint256 time
+    );
+
+    event GrantUpdatedFromFactory(
+        address indexed grantAddress,
+        uint96 indexed workspaceId,
+        string metadataHash,
+        uint256 time
+    );
 
     /**
      * @notice Constructor for initializing the Grant Implementation Contract
@@ -81,6 +98,21 @@ contract GrantFactory is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
         emit GrantCreated(_grantAddress, _workspaceId, _metadataHash, block.timestamp);
         applicationReviewReg.setRubrics(_workspaceId, _grantAddress, _rubricsMetadataHash);
         return _grantAddress;
+    }
+
+    /**
+     * @notice Function to update grant
+     * @param grantAddress Address of the grant contract that needs to be updated
+     * @param _workspaceId Workspace Id that the grant belongs to
+     * @param _metadataHash New URL that points to grant metadata
+     */
+    function updateGrant(
+        address grantAddress,
+        uint96 _workspaceId,
+        string memory _metadataHash
+    ) external onlyOwner {
+        IGrant(grantAddress).updateGrant(_metadataHash);
+        emit GrantUpdatedFromFactory(grantAddress, _workspaceId, _metadataHash, block.timestamp);
     }
 
     /**

--- a/contracts/GrantFactory.sol
+++ b/contracts/GrantFactory.sol
@@ -83,6 +83,7 @@ contract GrantFactory is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
                 _metadataHash,
                 _workspaceReg,
                 _applicationReg,
+                address(this),
                 owner()
             )
         );
@@ -101,18 +102,23 @@ contract GrantFactory is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
     function updateGrant(
         address grantAddress,
         uint96 _workspaceId,
+        IWorkspaceRegistry _workspaceReg,
         string memory _metadataHash
-    ) external onlyOwner {
+    ) external {
+        require(_workspaceReg.isWorkspaceAdmin(_workspaceId, msg.sender), "GrantUpdate: Unauthorised");
         IGrant(grantAddress).updateGrant(_metadataHash);
         bool active = IGrant(grantAddress).active();
+
         emit GrantUpdatedFromFactory(grantAddress, _workspaceId, _metadataHash, active, block.timestamp);
     }
 
     function updateGrantAccessibility(
         address grantAddress,
         uint96 _workspaceId,
+        IWorkspaceRegistry _workspaceReg,
         bool _canAcceptApplication
-    ) external onlyOwner {
+    ) external {
+        require(_workspaceReg.isWorkspaceAdmin(_workspaceId, msg.sender), "GrantUpdate: Unauthorised");
         IGrant(grantAddress).updateGrantAccessibility(_canAcceptApplication);
         string memory metadataHash = IGrant(grantAddress).metadataHash();
         emit GrantUpdatedFromFactory(grantAddress, _workspaceId, metadataHash, _canAcceptApplication, block.timestamp);

--- a/contracts/GrantFactory.sol
+++ b/contracts/GrantFactory.sol
@@ -25,19 +25,11 @@ contract GrantFactory is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
     /// @notice Emitted when a Grant implementation contract is upgraded
     event GrantImplementationUpdated(address grantAddress, bool success, bytes data);
 
-    /// @notice Emitted when a Grant is updated
-    event GrantUpdated(
-        address indexed grantAddress,
-        uint96 indexed workspaceId,
-        string metadataHash,
-        bool active,
-        uint256 time
-    );
-
     event GrantUpdatedFromFactory(
         address indexed grantAddress,
         uint96 indexed workspaceId,
         string metadataHash,
+        bool active,
         uint256 time
     );
 
@@ -112,7 +104,18 @@ contract GrantFactory is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
         string memory _metadataHash
     ) external onlyOwner {
         IGrant(grantAddress).updateGrant(_metadataHash);
-        emit GrantUpdatedFromFactory(grantAddress, _workspaceId, _metadataHash, block.timestamp);
+        bool active = IGrant(grantAddress).active();
+        emit GrantUpdatedFromFactory(grantAddress, _workspaceId, _metadataHash, active, block.timestamp);
+    }
+
+    function updateGrantAccessibility(
+        address grantAddress,
+        uint96 _workspaceId,
+        bool _canAcceptApplication
+    ) external onlyOwner {
+        IGrant(grantAddress).updateGrantAccessibility(_canAcceptApplication);
+        string memory metadataHash = IGrant(grantAddress).metadataHash();
+        emit GrantUpdatedFromFactory(grantAddress, _workspaceId, metadataHash, _canAcceptApplication, block.timestamp);
     }
 
     /**

--- a/contracts/GrantFactory.sol
+++ b/contracts/GrantFactory.sol
@@ -25,6 +25,7 @@ contract GrantFactory is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
     /// @notice Emitted when a Grant implementation contract is upgraded
     event GrantImplementationUpdated(address grantAddress, bool success, bytes data);
 
+    /// @notice Emitted when a grant is updated
     event GrantUpdatedFromFactory(
         address indexed grantAddress,
         uint96 indexed workspaceId,

--- a/contracts/interfaces/IGrant.sol
+++ b/contracts/interfaces/IGrant.sol
@@ -10,6 +10,8 @@ interface IGrant {
     /// and is invoked at the time of submitting application
     function incrementApplicant() external;
 
+    function metadataHash() external view returns (string memory);
+
     /// @notice It disburses reward to application owner using locked funds
     function disburseReward(
         uint96 _applicationId,
@@ -33,4 +35,6 @@ interface IGrant {
 
     /// @notice Update grant
     function updateGrant(string memory _metadataHash) external;
+
+    function updateGrantAccessibility(bool _canAcceptApplication) external;
 }

--- a/contracts/interfaces/IGrant.sol
+++ b/contracts/interfaces/IGrant.sol
@@ -33,8 +33,9 @@ interface IGrant {
     /// @notice Return the workspace id to which the grant belongs
     function workspaceId() external view returns (uint96);
 
-    /// @notice Update grant
+    /// @notice Update the metadata pointer of a grant, can be called by GrantFactory contract
     function updateGrant(string memory _metadataHash) external;
 
+    /// @notice Update grant accessibility, can be called by GrantFactory contract
     function updateGrantAccessibility(bool _canAcceptApplication) external;
 }

--- a/contracts/interfaces/IGrant.sol
+++ b/contracts/interfaces/IGrant.sol
@@ -30,4 +30,7 @@ interface IGrant {
 
     /// @notice Return the workspace id to which the grant belongs
     function workspaceId() external view returns (uint96);
+
+    /// @notice Update grant
+    function updateGrant(string memory _metadataHash) external;
 }


### PR DESCRIPTION
This PR is being raised so that the grant update functions get executed through the grantFactory contract instead of the contract `grant.sol`. This shifting was necessary for webwallet flow to function correctly.