### PR TITLE
fix: account for irregular application IDs

### DIFF
--- a/contracts/ApplicationRegistry.sol
+++ b/contracts/ApplicationRegistry.sol
@@ -162,6 +162,7 @@ contract ApplicationRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeab
         emit ApplicationSubmitted(_id, _grant, msg.sender, _metadataHash, _milestoneCount, block.timestamp);
         grantRef.incrementApplicant();
 
+        applicationReviewReg.appendToApplicationList(_id, _grant);
         /// @notice Whenever a new application is received, assign reviewers to it if auto-assigning is enabled
         if (applicationReviewReg.hasAutoAssigningEnabled(_grant)) {
             applicationReviewReg.assignReviewersRoundRobin(_workspaceId, _id, _grant);

--- a/contracts/ApplicationReviewRegistry.sol
+++ b/contracts/ApplicationReviewRegistry.sol
@@ -65,6 +65,9 @@ contract ApplicationReviewRegistry is Initializable, UUPSUpgradeable, OwnableUpg
     /// @notice mapping from grant address to list of reviewers
     mapping(address => address[]) public reviewers;
 
+    /// @notice mapping from grant address to list of applications
+    mapping(address => uint96[]) public applicationsToGrant;
+
     // --- Events ---
     /// @notice Emitted when reviewers are assigned
     event ReviewersAssigned(
@@ -343,8 +346,8 @@ contract ApplicationReviewRegistry is Initializable, UUPSUpgradeable, OwnableUpg
         reviewers[_grantAddress] = _activeReviewers;
 
         /// @notice Assign reviewers to already existing applications
-        for (uint96 i = 0; i < grantRef.numApplicants(); i++) {
-            assignReviewersRoundRobin(_workspaceId, i, _grantAddress);
+        for (uint96 i = 0; i < applicationsToGrant[_grantAddress].length; i++) {
+            assignReviewersRoundRobin(_workspaceId, applicationsToGrant[_grantAddress][i], _grantAddress);
         }
     }
 
@@ -491,5 +494,14 @@ contract ApplicationReviewRegistry is Initializable, UUPSUpgradeable, OwnableUpg
      */
     function hasAutoAssigningEnabled(address _grantAddress) external view returns (bool) {
         return isAutoAssigningEnabled[_grantAddress];
+    }
+
+    /**
+     * @notice Function to store the applications to a grant
+     * @param _grantAddress Grant address
+     * @param _applicationId Application ID
+     */
+    function appendToApplicationList(uint96 _applicationId, address _grantAddress) external {
+        applicationsToGrant[_grantAddress].push(_applicationId);
     }
 }

--- a/contracts/interfaces/IApplicationReviewRegistry.sol
+++ b/contracts/interfaces/IApplicationReviewRegistry.sol
@@ -17,4 +17,6 @@ interface IApplicationReviewRegistry {
     ) external;
 
     function hasAutoAssigningEnabled(address _grantAddress) external view returns (bool);
+
+    function appendToApplicationList(uint96 _applicationId, address _grantAddress) external;
 }

--- a/test/applicationReviewRegistry/ApplicationReviewRegistry.behavior.ts
+++ b/test/applicationReviewRegistry/ApplicationReviewRegistry.behavior.ts
@@ -98,7 +98,7 @@ export function shouldBehaveLikeApplicationReviewRegistry(): void {
     });
   });
 
-  describe("Auto assignment of Reviewers", function () {
+  describe.only("Auto assignment of Reviewers", function () {
     it("admin should be able to enable auto assigning of reviewers when one application is there", async function () {
       await this.workspaceRegistry.connect(this.signers.admin).updateWorkspaceMembers(
         0,


### PR DESCRIPTION
This PR invalidates the assumption that the application IDs are assigned serially while auto assigning reviewers to an application. Also, it clubs creation of a rubric with enabling auto assigning of reviewers.