### PR TITLE
fix: removed email and stored metadata hash

### DIFF
--- a/.openzeppelin/goerli.json
+++ b/.openzeppelin/goerli.json
@@ -981,22 +981,12 @@
           },
           "t_enum(ApplicationState)3061": {
             "label": "enum ApplicationRegistry.ApplicationState",
-            "members": [
-              "Submitted",
-              "Resubmit",
-              "Approved",
-              "Rejected",
-              "Complete"
-            ],
+            "members": ["Submitted", "Resubmit", "Approved", "Rejected", "Complete"],
             "numberOfBytes": "1"
           },
           "t_enum(MilestoneState)3055": {
             "label": "enum ApplicationRegistry.MilestoneState",
-            "members": [
-              "Submitted",
-              "Requested",
-              "Approved"
-            ],
+            "members": ["Submitted", "Requested", "Approved"],
             "numberOfBytes": "1"
           },
           "t_mapping(t_address,t_bool)": {
@@ -1483,22 +1473,12 @@
           },
           "t_enum(ApplicationState)3061": {
             "label": "enum ApplicationRegistry.ApplicationState",
-            "members": [
-              "Submitted",
-              "Resubmit",
-              "Approved",
-              "Rejected",
-              "Complete"
-            ],
+            "members": ["Submitted", "Resubmit", "Approved", "Rejected", "Complete"],
             "numberOfBytes": "1"
           },
           "t_enum(MilestoneState)3055": {
             "label": "enum ApplicationRegistry.MilestoneState",
-            "members": [
-              "Submitted",
-              "Requested",
-              "Approved"
-            ],
+            "members": ["Submitted", "Requested", "Approved"],
             "numberOfBytes": "1"
           },
           "t_mapping(t_address,t_bool)": {
@@ -3018,22 +2998,12 @@
           },
           "t_enum(ApplicationState)3104": {
             "label": "enum ApplicationRegistry.ApplicationState",
-            "members": [
-              "Submitted",
-              "Resubmit",
-              "Approved",
-              "Rejected",
-              "Complete"
-            ],
+            "members": ["Submitted", "Resubmit", "Approved", "Rejected", "Complete"],
             "numberOfBytes": "1"
           },
           "t_enum(MilestoneState)3098": {
             "label": "enum ApplicationRegistry.MilestoneState",
-            "members": [
-              "Submitted",
-              "Requested",
-              "Approved"
-            ],
+            "members": ["Submitted", "Requested", "Approved"],
             "numberOfBytes": "1"
           },
           "t_mapping(t_address,t_bool)": {
@@ -3924,22 +3894,12 @@
           },
           "t_enum(ApplicationState)3104": {
             "label": "enum ApplicationRegistry.ApplicationState",
-            "members": [
-              "Submitted",
-              "Resubmit",
-              "Approved",
-              "Rejected",
-              "Complete"
-            ],
+            "members": ["Submitted", "Resubmit", "Approved", "Rejected", "Complete"],
             "numberOfBytes": "1"
           },
           "t_enum(MilestoneState)3098": {
             "label": "enum ApplicationRegistry.MilestoneState",
-            "members": [
-              "Submitted",
-              "Requested",
-              "Approved"
-            ],
+            "members": ["Submitted", "Requested", "Approved"],
             "numberOfBytes": "1"
           },
           "t_mapping(t_address,t_bool)": {
@@ -5854,22 +5814,12 @@
           },
           "t_enum(ApplicationState)3104": {
             "label": "enum ApplicationRegistry.ApplicationState",
-            "members": [
-              "Submitted",
-              "Resubmit",
-              "Approved",
-              "Rejected",
-              "Complete"
-            ],
+            "members": ["Submitted", "Resubmit", "Approved", "Rejected", "Complete"],
             "numberOfBytes": "1"
           },
           "t_enum(MilestoneState)3098": {
             "label": "enum ApplicationRegistry.MilestoneState",
-            "members": [
-              "Submitted",
-              "Requested",
-              "Approved"
-            ],
+            "members": ["Submitted", "Requested", "Approved"],
             "numberOfBytes": "1"
           },
           "t_mapping(t_address,t_bool)": {
@@ -7115,22 +7065,12 @@
           },
           "t_enum(ApplicationState)3104": {
             "label": "enum ApplicationRegistry.ApplicationState",
-            "members": [
-              "Submitted",
-              "Resubmit",
-              "Approved",
-              "Rejected",
-              "Complete"
-            ],
+            "members": ["Submitted", "Resubmit", "Approved", "Rejected", "Complete"],
             "numberOfBytes": "1"
           },
           "t_enum(MilestoneState)3098": {
             "label": "enum ApplicationRegistry.MilestoneState",
-            "members": [
-              "Submitted",
-              "Requested",
-              "Approved"
-            ],
+            "members": ["Submitted", "Requested", "Approved"],
             "numberOfBytes": "1"
           },
           "t_mapping(t_address,t_bool)": {
@@ -8046,22 +7986,12 @@
           },
           "t_enum(ApplicationState)3104": {
             "label": "enum ApplicationRegistry.ApplicationState",
-            "members": [
-              "Submitted",
-              "Resubmit",
-              "Approved",
-              "Rejected",
-              "Complete"
-            ],
+            "members": ["Submitted", "Resubmit", "Approved", "Rejected", "Complete"],
             "numberOfBytes": "1"
           },
           "t_enum(MilestoneState)3098": {
             "label": "enum ApplicationRegistry.MilestoneState",
-            "members": [
-              "Submitted",
-              "Requested",
-              "Approved"
-            ],
+            "members": ["Submitted", "Requested", "Approved"],
             "numberOfBytes": "1"
           },
           "t_mapping(t_address,t_bool)": {
@@ -9084,6 +9014,242 @@
               {
                 "label": "safe",
                 "type": "t_struct(Safe)1576_storage",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          },
+          "t_uint96": {
+            "label": "uint96",
+            "numberOfBytes": "12"
+          }
+        }
+      }
+    },
+    "c766fcb3c3e73e58c46c316551cd195d4807b53570a521fa6d42d359bbc17624": {
+      "address": "0x9D318FC9f4a48bAAd53A836Cd0f69D1FC886dec5",
+      "txHash": "0x9afd3b751be29420478205fbfaf703e499c56264342b88cb9587f3654502c6f1",
+      "layout": {
+        "solcVersion": "0.8.7",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "workspaceCount",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_uint96",
+            "contract": "WorkspaceRegistry",
+            "src": "contracts/WorkspaceRegistry.sol:23"
+          },
+          {
+            "label": "workspaces",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_mapping(t_uint96,t_struct(Workspace)6237_storage)",
+            "contract": "WorkspaceRegistry",
+            "src": "contracts/WorkspaceRegistry.sol:42"
+          },
+          {
+            "label": "memberRoles",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_mapping(t_uint96,t_mapping(t_address,t_bytes32))",
+            "contract": "WorkspaceRegistry",
+            "src": "contracts/WorkspaceRegistry.sol:45"
+          },
+          {
+            "label": "anonAuthoriserAddress",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_address",
+            "contract": "WorkspaceRegistry",
+            "src": "contracts/WorkspaceRegistry.sol:48"
+          },
+          {
+            "label": "applicationReg",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_contract(IApplicationRegistry)7492",
+            "contract": "WorkspaceRegistry",
+            "src": "contracts/WorkspaceRegistry.sol:51"
+          },
+          {
+            "label": "qbAdmins",
+            "offset": 0,
+            "slot": "256",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "WorkspaceRegistry",
+            "src": "contracts/WorkspaceRegistry.sol:54"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(IApplicationRegistry)7492": {
+            "label": "contract IApplicationRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bytes32)": {
+            "label": "mapping(address => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint96,t_mapping(t_address,t_bytes32))": {
+            "label": "mapping(uint96 => mapping(address => bytes32))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint96,t_struct(Workspace)6237_storage)": {
+            "label": "mapping(uint96 => struct WorkspaceRegistry.Workspace)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Safe)6227_storage": {
+            "label": "struct WorkspaceRegistry.Safe",
+            "members": [
+              {
+                "label": "_address",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "chainId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Workspace)6237_storage": {
+            "label": "struct WorkspaceRegistry.Workspace",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_uint96",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "owner",
+                "type": "t_address",
+                "offset": 12,
+                "slot": "0"
+              },
+              {
+                "label": "metadataHash",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "safe",
+                "type": "t_struct(Safe)6227_storage",
                 "offset": 0,
                 "slot": "2"
               }

--- a/abis/WorkspaceRegistry.json
+++ b/abis/WorkspaceRegistry.json
@@ -932,7 +932,7 @@
       },
       {
         "internalType": "string[]",
-        "name": "_emails",
+        "name": "_metadataHashes",
         "type": "string[]"
       }
     ],

--- a/contracts/WorkspaceRegistry.sol
+++ b/contracts/WorkspaceRegistry.sol
@@ -285,18 +285,18 @@ contract WorkspaceRegistry is
      * @param _members Members whose roles are to be updated
      * @param _roles Roles to be updated
      * @param _enabled Whether to enable or disable the role
-     * @param _emails Emails of members.
+     * @param _metadataHashes Metadatas for the members.
      */
     function updateWorkspaceMembers(
         uint96 _id,
         address[] memory _members,
         uint8[] memory _roles,
         bool[] memory _enabled,
-        string[] memory _emails
+        string[] memory _metadataHashes
     ) external whenNotPaused onlyWorkspaceAdmin(_id) withinLimit(_members.length) {
         require(_members.length == _roles.length, "UpdateWorkspaceMembers: Parameters length mismatch");
         require(_members.length == _enabled.length, "UpdateWorkspaceMembers: Parameters length mismatch");
-        require(_members.length == _emails.length, "UpdateWorkspaceMembers: Parameters length mismatch");
+        require(_members.length == _metadataHashes.length, "UpdateWorkspaceMembers: Parameters length mismatch");
         for (uint256 i = 0; i < _members.length; i++) {
             address member = _members[i];
             /// @notice The role 0 denotes an admin role
@@ -304,8 +304,8 @@ contract WorkspaceRegistry is
             uint8 role = _roles[i];
             bool enabled = _enabled[i];
             _setRole(_id, member, role, enabled);
+            emit WorkspaceMemberUpdated(_id, member, role, enabled, _metadataHashes[i], block.timestamp);
         }
-        emit WorkspaceMembersUpdated(_id, _members, _roles, _enabled, _emails, block.timestamp);
     }
 
     /**


### PR DESCRIPTION
This PR updates the `updateWorkspaceMember` function to include metadata hashes as a part of the parameter list and not the user emails.