### PR TITLE
Assignment of reviewers

### DIFF
--- a/.openzeppelin/goerli.json
+++ b/.openzeppelin/goerli.json
@@ -11477,7 +11477,7 @@
             "label": "workspaceReg",
             "offset": 0,
             "slot": "201",
-            "type": "t_contract(IWorkspaceRegistry)2870",
+            "type": "t_contract(IWorkspaceRegistry)7445",
             "contract": "ApplicationReviewRegistry",
             "src": "contracts/ApplicationReviewRegistry.sol:40"
           },
@@ -11485,7 +11485,7 @@
             "label": "grantFactory",
             "offset": 0,
             "slot": "202",
-            "type": "t_contract(IGrantFactory)2846",
+            "type": "t_contract(IGrantFactory)7421",
             "contract": "ApplicationReviewRegistry",
             "src": "contracts/ApplicationReviewRegistry.sol:43"
           },
@@ -11493,7 +11493,7 @@
             "label": "applicationReg",
             "offset": 0,
             "slot": "203",
-            "type": "t_contract(IApplicationRegistry)2723",
+            "type": "t_contract(IApplicationRegistry)7298",
             "contract": "ApplicationReviewRegistry",
             "src": "contracts/ApplicationReviewRegistry.sol:46"
           },
@@ -11509,7 +11509,7 @@
             "label": "reviews",
             "offset": 0,
             "slot": "204",
-            "type": "t_mapping(t_address,t_mapping(t_uint96,t_struct(Review)1265_storage))",
+            "type": "t_mapping(t_address,t_mapping(t_uint96,t_struct(Review)3274_storage))",
             "contract": "ApplicationReviewRegistry",
             "src": "contracts/ApplicationReviewRegistry.sol:52"
           },
@@ -11517,7 +11517,7 @@
             "label": "grantReviewStates",
             "offset": 0,
             "slot": "205",
-            "type": "t_mapping(t_address,t_struct(GrantReviewState)1276_storage)",
+            "type": "t_mapping(t_address,t_struct(GrantReviewState)3285_storage)",
             "contract": "ApplicationReviewRegistry",
             "src": "contracts/ApplicationReviewRegistry.sol:55"
           },
@@ -11595,15 +11595,15 @@
             "label": "bool",
             "numberOfBytes": "1"
           },
-          "t_contract(IApplicationRegistry)2723": {
+          "t_contract(IApplicationRegistry)7298": {
             "label": "contract IApplicationRegistry",
             "numberOfBytes": "20"
           },
-          "t_contract(IGrantFactory)2846": {
+          "t_contract(IGrantFactory)7421": {
             "label": "contract IGrantFactory",
             "numberOfBytes": "20"
           },
-          "t_contract(IWorkspaceRegistry)2870": {
+          "t_contract(IWorkspaceRegistry)7445": {
             "label": "contract IWorkspaceRegistry",
             "numberOfBytes": "20"
           },
@@ -11623,11 +11623,11 @@
             "label": "mapping(address => mapping(address => uint96))",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_address,t_mapping(t_uint96,t_struct(Review)1265_storage))": {
+          "t_mapping(t_address,t_mapping(t_uint96,t_struct(Review)3274_storage))": {
             "label": "mapping(address => mapping(uint96 => struct ApplicationReviewRegistry.Review))",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_address,t_struct(GrantReviewState)1276_storage)": {
+          "t_mapping(t_address,t_struct(GrantReviewState)3285_storage)": {
             "label": "mapping(address => struct ApplicationReviewRegistry.GrantReviewState)",
             "numberOfBytes": "32"
           },
@@ -11643,7 +11643,7 @@
             "label": "mapping(uint96 => bool)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_uint96,t_struct(Review)1265_storage)": {
+          "t_mapping(t_uint96,t_struct(Review)3274_storage)": {
             "label": "mapping(uint96 => struct ApplicationReviewRegistry.Review)",
             "numberOfBytes": "32"
           },
@@ -11651,7 +11651,7 @@
             "label": "string",
             "numberOfBytes": "32"
           },
-          "t_struct(GrantReviewState)1276_storage": {
+          "t_struct(GrantReviewState)3285_storage": {
             "label": "struct ApplicationReviewRegistry.GrantReviewState",
             "members": [
               {
@@ -11687,7 +11687,7 @@
             ],
             "numberOfBytes": "128"
           },
-          "t_struct(Review)1265_storage": {
+          "t_struct(Review)3274_storage": {
             "label": "struct ApplicationReviewRegistry.Review",
             "members": [
               {
@@ -11982,6 +11982,346 @@
           "t_uint8": {
             "label": "uint8",
             "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "452c6c33d819107b74577f1f9ff998c0aa996dc49f60a4258ce7d66c419e6432": {
+      "address": "0x98e449dc57DFbD696d58EbF95BDE3b7D7fE2d0c9",
+      "txHash": "0x80c8034fd91aacbd3f85e06745924acc8e21eb9c3825b0dcc86a0eaacd5dd41f",
+      "layout": {
+        "solcVersion": "0.8.7",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "workspaceReg",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_contract(IWorkspaceRegistry)3318",
+            "contract": "ApplicationReviewRegistry",
+            "src": "contracts/ApplicationReviewRegistry.sol:40"
+          },
+          {
+            "label": "grantFactory",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_contract(IGrantFactory)3294",
+            "contract": "ApplicationReviewRegistry",
+            "src": "contracts/ApplicationReviewRegistry.sol:43"
+          },
+          {
+            "label": "applicationReg",
+            "offset": 0,
+            "slot": "203",
+            "type": "t_contract(IApplicationRegistry)3171",
+            "contract": "ApplicationReviewRegistry",
+            "src": "contracts/ApplicationReviewRegistry.sol:46"
+          },
+          {
+            "label": "reviewCount",
+            "offset": 20,
+            "slot": "203",
+            "type": "t_uint96",
+            "contract": "ApplicationReviewRegistry",
+            "src": "contracts/ApplicationReviewRegistry.sol:49"
+          },
+          {
+            "label": "reviews",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_mapping(t_address,t_mapping(t_uint96,t_struct(Review)1265_storage))",
+            "contract": "ApplicationReviewRegistry",
+            "src": "contracts/ApplicationReviewRegistry.sol:52"
+          },
+          {
+            "label": "grantReviewStates",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_mapping(t_address,t_struct(GrantReviewState)1276_storage)",
+            "contract": "ApplicationReviewRegistry",
+            "src": "contracts/ApplicationReviewRegistry.sol:55"
+          },
+          {
+            "label": "reviewPaymentsStatus",
+            "offset": 0,
+            "slot": "206",
+            "type": "t_mapping(t_uint96,t_bool)",
+            "contract": "ApplicationReviewRegistry",
+            "src": "contracts/ApplicationReviewRegistry.sol:58"
+          },
+          {
+            "label": "isAutoAssigningEnabled",
+            "offset": 0,
+            "slot": "207",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ApplicationReviewRegistry",
+            "src": "contracts/ApplicationReviewRegistry.sol:61"
+          },
+          {
+            "label": "reviewerAssignmentCounts",
+            "offset": 0,
+            "slot": "208",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint96))",
+            "contract": "ApplicationReviewRegistry",
+            "src": "contracts/ApplicationReviewRegistry.sol:64"
+          },
+          {
+            "label": "reviewers",
+            "offset": 0,
+            "slot": "209",
+            "type": "t_mapping(t_address,t_array(t_address)dyn_storage)",
+            "contract": "ApplicationReviewRegistry",
+            "src": "contracts/ApplicationReviewRegistry.sol:67"
+          },
+          {
+            "label": "applicationsToGrant",
+            "offset": 0,
+            "slot": "210",
+            "type": "t_mapping(t_address,t_array(t_uint96)dyn_storage)",
+            "contract": "ApplicationReviewRegistry",
+            "src": "contracts/ApplicationReviewRegistry.sol:70"
+          },
+          {
+            "label": "lastAssignedReviewerIndices",
+            "offset": 0,
+            "slot": "211",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ApplicationReviewRegistry",
+            "src": "contracts/ApplicationReviewRegistry.sol:73"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint96)dyn_storage": {
+            "label": "uint96[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IApplicationRegistry)3171": {
+            "label": "contract IApplicationRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IGrantFactory)3294": {
+            "label": "contract IGrantFactory",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IWorkspaceRegistry)3318": {
+            "label": "contract IWorkspaceRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_array(t_address)dyn_storage)": {
+            "label": "mapping(address => address[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_array(t_uint96)dyn_storage)": {
+            "label": "mapping(address => uint96[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint96))": {
+            "label": "mapping(address => mapping(address => uint96))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint96,t_struct(Review)1265_storage))": {
+            "label": "mapping(address => mapping(uint96 => struct ApplicationReviewRegistry.Review))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(GrantReviewState)1276_storage)": {
+            "label": "mapping(address => struct ApplicationReviewRegistry.GrantReviewState)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint96)": {
+            "label": "mapping(address => uint96)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint96,t_bool)": {
+            "label": "mapping(uint96 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint96,t_struct(Review)1265_storage)": {
+            "label": "mapping(uint96 => struct ApplicationReviewRegistry.Review)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(GrantReviewState)1276_storage": {
+            "label": "struct ApplicationReviewRegistry.GrantReviewState",
+            "members": [
+              {
+                "label": "grant",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "workspaceId",
+                "type": "t_uint96",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "numOfReviews",
+                "type": "t_uint96",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "rubricsMetadataHash",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "numOfReviewersPerApplication",
+                "type": "t_uint96",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(Review)1265_storage": {
+            "label": "struct ApplicationReviewRegistry.Review",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_uint96",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "workspaceId",
+                "type": "t_uint96",
+                "offset": 12,
+                "slot": "0"
+              },
+              {
+                "label": "applicationId",
+                "type": "t_uint96",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "grant",
+                "type": "t_address",
+                "offset": 12,
+                "slot": "1"
+              },
+              {
+                "label": "reviewer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "metadataHash",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "active",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          },
+          "t_uint96": {
+            "label": "uint96",
+            "numberOfBytes": "12"
           }
         }
       }

--- a/contracts/ApplicationRegistry.sol
+++ b/contracts/ApplicationRegistry.sol
@@ -404,4 +404,9 @@ contract ApplicationRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeab
         Application memory application = applications[_applicationId];
         return application.workspaceId;
     }
+
+    function isSubmittedApplication(uint96 _applicationId) external view override returns (bool) {
+        Application memory application = applications[_applicationId];
+        return application.state == ApplicationState.Submitted;
+    }
 }

--- a/contracts/ApplicationReviewRegistry.sol
+++ b/contracts/ApplicationReviewRegistry.sol
@@ -334,6 +334,7 @@ contract ApplicationReviewRegistry is Initializable, UUPSUpgradeable, OwnableUpg
         uint96 _applicationId,
         address _grantAddress
     ) public override {
+        require(msg.sender == address(applicationReg), "AssignReviewers (Batch): Unauthorised");
         require(
             applicationReg.getApplicationWorkspace(_applicationId) == _workspaceId,
             "AssignReviewers (Batch): Unauthorized"
@@ -546,7 +547,7 @@ contract ApplicationReviewRegistry is Initializable, UUPSUpgradeable, OwnableUpg
         address _grantAddress,
         address[] memory _reviewers,
         uint96[] memory _applications
-    ) public onlyWorkspaceAdminOrGrantFactory(_workspaceId) {
+    ) public onlyWorkspaceAdmin(_workspaceId) {
         IGrant grantRef = IGrant(_grantAddress);
         require(grantRef.workspaceId() == _workspaceId, "AutoAssignReviewers: Unauthorised");
         for (uint256 i = 0; i < _reviewers.length; i++) {

--- a/contracts/ApplicationReviewRegistry.sol
+++ b/contracts/ApplicationReviewRegistry.sol
@@ -555,46 +555,6 @@ contract ApplicationReviewRegistry is Initializable, UUPSUpgradeable, OwnableUpg
     }
 
     /**
-     * @notice resets the rubric data for a set of reviewers of a grant
-     * @notice especially useful if the admin wants to start afresh
-     * @param _workspaceId Workspace id
-     * @param _grantAddress Grant address
-     * @param _reviewers Array of reviewer addresses
-     * @param _applications Array of application ids
-     */
-    function resetAllReviewerData(
-        uint96 _workspaceId,
-        address _grantAddress,
-        address[] memory _reviewers,
-        uint96[] memory _applications
-    ) public onlyWorkspaceAdmin(_workspaceId) {
-        IGrant grantRef = IGrant(_grantAddress);
-        require(grantRef.workspaceId() == _workspaceId, "AutoAssignReviewers: Unauthorised");
-        for (uint256 i = 0; i < _reviewers.length; i++) {
-            require(
-                workspaceReg.isWorkspaceAdminOrReviewer(_workspaceId, _reviewers[i]),
-                "AutoAssignReviewers: Unauthorised"
-            );
-            for (uint256 j = 0; j < _applications.length; ++j) {
-                require(
-                    applicationReg.getApplicationWorkspace(_applications[i]) == _workspaceId,
-                    "AutoAssignReviewers: Unauthorised"
-                );
-                delete reviews[_reviewers[i]][_applications[j]];
-            }
-        }
-
-        isAutoAssigningEnabled[_grantAddress] = false;
-        delete reviewers[_grantAddress];
-
-        GrantReviewState storage grantReviewState = grantReviewStates[_grantAddress];
-        grantReviewState.numOfReviewersPerApplication = 0;
-        grantReviewState.numOfReviews = 0;
-
-        emit ReviewerDataReset(_workspaceId, _grantAddress, msg.sender, block.timestamp);
-    }
-
-    /**
      * @notice Submits a review for an application
      * @param _workspaceId Workspace id
      * @param _applicationId Application id

--- a/contracts/ApplicationReviewRegistry.sol
+++ b/contracts/ApplicationReviewRegistry.sol
@@ -414,9 +414,9 @@ contract ApplicationReviewRegistry is Initializable, UUPSUpgradeable, OwnableUpg
         /// @notice Assign reviewers to already existing applications
         uint256 submittedApplicationCount = 0;
         for (uint96 i = 0; i < applicationsToGrant[_grantAddress].length; i++) {
-            // assignReviewersRoundRobin(_workspaceId, applicationsToGrant[_grantAddress][i], _grantAddress);
-            if (applicationReg.isSubmittedApplication(applicationsToGrant[_grantAddress][i]))
-                submittedApplicationCount += 1;
+            submittedApplicationCount += applicationReg.isSubmittedApplication(applicationsToGrant[_grantAddress][i])
+                ? 1
+                : 0;
         }
 
         uint96[] memory submittedApplications = new uint96[](submittedApplicationCount);
@@ -431,7 +431,6 @@ contract ApplicationReviewRegistry is Initializable, UUPSUpgradeable, OwnableUpg
         uint256 lastReviewerIndex = 0;
         address[] memory _reviewersToBeAssigned = new address[](_numOfReviewersPerApplication);
         bool[] memory _active = new bool[](_numOfReviewersPerApplication);
-        for (uint256 i = 0; i < _numOfReviewersPerApplication; ++i) _active[i] = true;
 
         for (uint256 i = 0; i < submittedApplications.length; ++i) {
             for (j = 0; j < _numOfReviewersPerApplication; ++j) {

--- a/contracts/ApplicationReviewRegistry.sol
+++ b/contracts/ApplicationReviewRegistry.sol
@@ -459,6 +459,13 @@ contract ApplicationReviewRegistry is Initializable, UUPSUpgradeable, OwnableUpg
         );
     }
 
+    /**
+     * @notice updates the auto assignment config of reviewers
+     * @param _workspaceId Workspace id
+     * @param _grantAddress Grant address
+     * @param _reviewers Array of reviewer addresses
+     * @param _numOfReviewersPerApplication Number of reviewers per application when auto assigning
+     */
     function updateAutoAssignmentOfReviewers(
         uint96 _workspaceId,
         address _grantAddress,
@@ -519,6 +526,11 @@ contract ApplicationReviewRegistry is Initializable, UUPSUpgradeable, OwnableUpg
         );
     }
 
+    /**
+     * @notice disables auto assignment for a grant
+     * @param _workspaceId Workspace id
+     * @param _grantAddress Grant address
+     */
     function disableAutoAssignment(uint96 _workspaceId, address _grantAddress)
         public
         onlyWorkspaceAdminOrGrantFactory(_workspaceId)
@@ -542,6 +554,14 @@ contract ApplicationReviewRegistry is Initializable, UUPSUpgradeable, OwnableUpg
         );
     }
 
+    /**
+     * @notice resets the rubric data for a set of reviewers of a grant
+     * @notice especially useful if the admin wants to start afresh
+     * @param _workspaceId Workspace id
+     * @param _grantAddress Grant address
+     * @param _reviewers Array of reviewer addresses
+     * @param _applications Array of application ids
+     */
     function resetAllReviewerData(
         uint96 _workspaceId,
         address _grantAddress,

--- a/contracts/ApplicationReviewRegistry.sol
+++ b/contracts/ApplicationReviewRegistry.sol
@@ -136,6 +136,18 @@ contract ApplicationReviewRegistry is Initializable, UUPSUpgradeable, OwnableUpg
         uint256 time
     );
 
+    event AutoAssignmentUpdated(
+        uint96 _workspaceId,
+        address _grantAddress,
+        address[] _reviewers,
+        uint96 _numberOfReviewersPerApplication,
+        bool _enabled,
+        address _updatedBy,
+        uint256 time
+    );
+
+    event ReviewerDataReset(uint96 _workspaceId, address _grantAddress, address _resetBy, uint256 time);
+
     modifier onlyWorkspaceAdmin(uint96 _workspaceId) {
         require(workspaceReg.isWorkspaceAdmin(_workspaceId, msg.sender), "Unauthorised: Not an admin");
         _;
@@ -296,9 +308,7 @@ contract ApplicationReviewRegistry is Initializable, UUPSUpgradeable, OwnableUpg
 
             if (_active[i]) {
                 uint96 _assignmentCount = reviewerAssignmentCounts[_grantAddress][_reviewers[i]];
-                assert(_assignmentCount + 1 > _assignmentCount);
-                _assignmentCount += 1;
-                reviewerAssignmentCounts[_grantAddress][_reviewers[i]] = _assignmentCount;
+                reviewerAssignmentCounts[_grantAddress][_reviewers[i]] = _assignmentCount + 1;
             }
         }
 
@@ -344,8 +354,8 @@ contract ApplicationReviewRegistry is Initializable, UUPSUpgradeable, OwnableUpg
         for (uint256 i = 0; i < numOfReviewersPerApplication; i++) {
             _leastBusyReviewers[i] = _reviewers[lastIndex];
             _activeReviewers[i] = true;
-            lastIndex++;
-            if (lastIndex > _reviewers.length - 1) {
+            ++lastIndex;
+            if (lastIndex == _reviewers.length) {
                 lastIndex = 0;
             }
         }
@@ -353,6 +363,16 @@ contract ApplicationReviewRegistry is Initializable, UUPSUpgradeable, OwnableUpg
 
         // Step - 3: Assign the filtered list of reviewers to the application
         assignReviewers(_workspaceId, _applicationId, _grantAddress, _leastBusyReviewers, _activeReviewers);
+
+        emit AutoAssignmentUpdated(
+            _workspaceId,
+            _grantAddress,
+            _reviewers,
+            numOfReviewersPerApplication,
+            isAutoAssigningEnabled[_grantAddress],
+            msg.sender,
+            block.timestamp
+        );
     }
 
     /**
@@ -361,14 +381,12 @@ contract ApplicationReviewRegistry is Initializable, UUPSUpgradeable, OwnableUpg
      * @param _workspaceId Workspace id
      * @param _grantAddress Grant address
      * @param _reviewers Array of reviewer addresses
-     * @param _active Array of boolean values indicating whether the reviewers are active or not
      * @param _numOfReviewersPerApplication Number of reviewers per application when auto assigning
      */
     function enableAutoAssignmentOfReviewers(
         uint96 _workspaceId,
         address _grantAddress,
         address[] memory _reviewers,
-        bool[] memory _active,
         uint96 _numOfReviewersPerApplication
     ) private onlyWorkspaceAdminOrGrantFactory(_workspaceId) {
         require(_numOfReviewersPerApplication > 0, "AutoAssignReviewers: Reviewers per application must be positive");
@@ -376,35 +394,184 @@ contract ApplicationReviewRegistry is Initializable, UUPSUpgradeable, OwnableUpg
         IGrant grantRef = IGrant(_grantAddress);
         require(grantRef.workspaceId() == _workspaceId, "AutoAssignReviewers: Unauthorised");
         require(isAutoAssigningEnabled[_grantAddress] == false, "AutoAssignReviewers: Auto assignment already enabled");
+        require(
+            _reviewers.length >= _numOfReviewersPerApplication,
+            "AutoAssignReviewers: Not enough reviewers selected"
+        );
+        for (uint256 i = 0; i < _reviewers.length; ++i) {
+            require(
+                workspaceReg.isWorkspaceAdminOrReviewer(_workspaceId, _reviewers[i]),
+                "AutoAssignReviewers: Not a reviewer"
+            );
+        }
+
         isAutoAssigningEnabled[_grantAddress] = true;
 
-        uint96 trueCount = 0;
-        for (uint256 i = 0; i < _active.length; i++) {
-            if (_active[i]) {
-                assert(trueCount + 1 > trueCount);
-                trueCount += 1;
+        GrantReviewState storage grantReviewState = grantReviewStates[_grantAddress];
+        grantReviewState.numOfReviewersPerApplication = _numOfReviewersPerApplication;
+        reviewers[_grantAddress] = _reviewers;
+
+        /// @notice Assign reviewers to already existing applications
+        uint256 submittedApplicationCount = 0;
+        for (uint96 i = 0; i < applicationsToGrant[_grantAddress].length; i++) {
+            // assignReviewersRoundRobin(_workspaceId, applicationsToGrant[_grantAddress][i], _grantAddress);
+            if (applicationReg.isSubmittedApplication(applicationsToGrant[_grantAddress][i]))
+                submittedApplicationCount += 1;
+        }
+
+        uint96[] memory submittedApplications = new uint96[](submittedApplicationCount);
+        uint256 j = 0;
+        for (uint96 i = 0; i < applicationsToGrant[_grantAddress].length; i++) {
+            // assignReviewersRoundRobin(_workspaceId, applicationsToGrant[_grantAddress][i], _grantAddress);
+            if (applicationReg.isSubmittedApplication(applicationsToGrant[_grantAddress][i])) {
+                submittedApplications[j] = applicationsToGrant[_grantAddress][i];
             }
         }
-        require(trueCount >= _numOfReviewersPerApplication, "AutoAssignReviewers: Not enough reviewers selected");
+
+        uint256 lastReviewerIndex = 0;
+        address[] memory _reviewersToBeAssigned = new address[](_numOfReviewersPerApplication);
+        bool[] memory _active = new bool[](_numOfReviewersPerApplication);
+        for (uint256 i = 0; i < _numOfReviewersPerApplication; ++i) _active[i] = true;
+
+        for (uint256 i = 0; i < submittedApplications.length; ++i) {
+            for (j = 0; j < _numOfReviewersPerApplication; ++j) {
+                _reviewersToBeAssigned[j] = _reviewers[lastReviewerIndex];
+                _active[j] = true;
+                ++lastReviewerIndex;
+                if (lastReviewerIndex == _reviewers.length) {
+                    lastReviewerIndex = 0;
+                }
+            }
+
+            assignReviewers(_workspaceId, submittedApplications[i], _grantAddress, _reviewersToBeAssigned, _active);
+        }
+
+        lastAssignedReviewerIndices[_grantAddress] = lastReviewerIndex;
+
+        emit AutoAssignmentUpdated(
+            _workspaceId,
+            _grantAddress,
+            _reviewers,
+            _numOfReviewersPerApplication,
+            true,
+            msg.sender,
+            block.timestamp
+        );
+    }
+
+    function updateAutoAssignmentOfReviewers(
+        uint96 _workspaceId,
+        address _grantAddress,
+        address[] memory _reviewers,
+        uint96 _numOfReviewersPerApplication
+    ) public onlyWorkspaceAdminOrGrantFactory(_workspaceId) {
+        require(_numOfReviewersPerApplication > 0, "AutoAssignReviewers: Reviewers per application must be positive");
+
+        IGrant grantRef = IGrant(_grantAddress);
+        require(grantRef.workspaceId() == _workspaceId, "AutoAssignReviewers: Unauthorised");
+        require(isAutoAssigningEnabled[_grantAddress], "AutoAssignReviewers: Auto assignment not enabled");
+        require(
+            _reviewers.length >= _numOfReviewersPerApplication,
+            "AutoAssignReviewers: Not enough reviewers selected"
+        );
+
+        for (uint256 k = 0; k < _reviewers.length; ++k) {
+            require(
+                workspaceReg.isWorkspaceAdminOrReviewer(_workspaceId, _reviewers[k]),
+                "AutoAssignReviewers: Not a reviewer"
+            );
+        }
 
         GrantReviewState storage grantReviewState = grantReviewStates[_grantAddress];
         grantReviewState.numOfReviewersPerApplication = _numOfReviewersPerApplication;
 
-        address[] memory _activeReviewers = new address[](trueCount);
-        uint256 j = 0;
-        for (uint256 i = 0; i < trueCount; i++) {
-            if (_active[i]) {
-                _activeReviewers[j] = _reviewers[i];
-                j += 1;
+        uint256[] memory counts = new uint256[](_reviewers.length);
+        for (uint256 k = 0; k < _reviewers.length; ++k)
+            counts[k] = reviewerAssignmentCounts[_grantAddress][_reviewers[k]];
+
+        uint256 i = 1;
+        while (i < _reviewers.length) {
+            uint256 x = counts[i];
+            address y = _reviewers[i];
+            uint256 j = i - 1;
+            while (j >= 0 && counts[j] > x) {
+                counts[j + 1] = counts[j];
+                _reviewers[j + 1] = _reviewers[j];
+                --j;
+            }
+
+            counts[j + 1] = x;
+            _reviewers[j + 1] = y;
+            ++i;
+        }
+
+        reviewers[_grantAddress] = _reviewers;
+        lastAssignedReviewerIndices[_grantAddress] = 0;
+
+        emit AutoAssignmentUpdated(
+            _workspaceId,
+            _grantAddress,
+            _reviewers,
+            _numOfReviewersPerApplication,
+            true,
+            msg.sender,
+            block.timestamp
+        );
+    }
+
+    function disableAutoAssignment(uint96 _workspaceId, address _grantAddress)
+        public
+        onlyWorkspaceAdminOrGrantFactory(_workspaceId)
+    {
+        IGrant grantRef = IGrant(_grantAddress);
+        require(grantRef.workspaceId() == _workspaceId, "AutoAssignReviewers: Unauthorised");
+        require(isAutoAssigningEnabled[_grantAddress], "AutoAssignReviewers: Auto assignment not enabled");
+
+        isAutoAssigningEnabled[_grantAddress] = false;
+
+        GrantReviewState storage grantReviewState = grantReviewStates[_grantAddress];
+
+        emit AutoAssignmentUpdated(
+            _workspaceId,
+            _grantAddress,
+            reviewers[_grantAddress],
+            grantReviewState.numOfReviewersPerApplication,
+            false,
+            msg.sender,
+            block.timestamp
+        );
+    }
+
+    function resetAllReviewerData(
+        uint96 _workspaceId,
+        address _grantAddress,
+        address[] memory _reviewers,
+        uint96[] memory _applications
+    ) public onlyWorkspaceAdminOrGrantFactory(_workspaceId) {
+        IGrant grantRef = IGrant(_grantAddress);
+        require(grantRef.workspaceId() == _workspaceId, "AutoAssignReviewers: Unauthorised");
+        for (uint256 i = 0; i < _reviewers.length; i++) {
+            require(
+                workspaceReg.isWorkspaceAdminOrReviewer(_workspaceId, _reviewers[i]),
+                "AutoAssignReviewers: Unauthorised"
+            );
+            for (uint256 j = 0; j < _applications.length; ++j) {
+                require(
+                    applicationReg.getApplicationWorkspace(_applications[i]) == _workspaceId,
+                    "AutoAssignReviewers: Unauthorised"
+                );
+                delete reviews[_reviewers[i]][_applications[j]];
             }
         }
 
-        reviewers[_grantAddress] = _activeReviewers;
+        isAutoAssigningEnabled[_grantAddress] = false;
+        delete reviewers[_grantAddress];
 
-        /// @notice Assign reviewers to already existing applications
-        for (uint96 i = 0; i < applicationsToGrant[_grantAddress].length; i++) {
-            assignReviewersRoundRobin(_workspaceId, applicationsToGrant[_grantAddress][i], _grantAddress);
-        }
+        GrantReviewState storage grantReviewState = grantReviewStates[_grantAddress];
+        grantReviewState.numOfReviewersPerApplication = 0;
+        grantReviewState.numOfReviews = 0;
+
+        emit ReviewerDataReset(_workspaceId, _grantAddress, msg.sender, block.timestamp);
     }
 
     /**
@@ -484,7 +651,6 @@ contract ApplicationReviewRegistry is Initializable, UUPSUpgradeable, OwnableUpg
      * @param _workspaceId Workspace id
      * @param _grantAddress Grant address
      * @param _reviewers Array of reviewer addresses
-     * @param _active Array of boolean values indicating whether the reviewers are active or not
      * @param _numOfReviewersPerApplication Number of reviewers per application when auto assigning
      * @param _rubricMetadataHash IPFS hash of the rubrics metadata
      */
@@ -492,19 +658,12 @@ contract ApplicationReviewRegistry is Initializable, UUPSUpgradeable, OwnableUpg
         uint96 _workspaceId,
         address _grantAddress,
         address[] memory _reviewers,
-        bool[] memory _active,
         uint96 _numOfReviewersPerApplication,
         string memory _rubricMetadataHash
     ) external onlyWorkspaceAdminOrGrantFactory(_workspaceId) {
         require(IGrant(_grantAddress).workspaceId() == _workspaceId, "RubricsSetAndEnableAutoAssign: Unauthorised");
         setRubrics(_workspaceId, _grantAddress, _numOfReviewersPerApplication, _rubricMetadataHash);
-        enableAutoAssignmentOfReviewers(
-            _workspaceId,
-            _grantAddress,
-            _reviewers,
-            _active,
-            _numOfReviewersPerApplication
-        );
+        enableAutoAssignmentOfReviewers(_workspaceId, _grantAddress, _reviewers, _numOfReviewersPerApplication);
     }
 
     /**

--- a/contracts/interfaces/IApplicationRegistry.sol
+++ b/contracts/interfaces/IApplicationRegistry.sol
@@ -10,4 +10,6 @@ interface IApplicationRegistry {
     function getApplicationWorkspace(uint96 _applicationId) external view returns (uint96);
 
     function migrateWallet(address fromWallet, address toWallet) external;
+
+    function isSubmittedApplication(uint96 _applicationId) external view returns (bool);
 }

--- a/test/applicationReviewRegistry/ApplicationReviewRegistry.behavior.ts
+++ b/test/applicationReviewRegistry/ApplicationReviewRegistry.behavior.ts
@@ -614,7 +614,7 @@ export function shouldBehaveLikeApplicationReviewRegistry(): void {
       expect(distribution).eqls(newDistributionFromContract);
     });
 
-    it.only("should assign updated num of reviewers to new applications", async function () {
+    it("should assign updated num of reviewers to new applications", async function () {
       const reviewerCount = 10;
 
       const reviewers: Wallet[] = [];

--- a/test/applicationReviewRegistry/ApplicationReviewRegistry.behavior.ts
+++ b/test/applicationReviewRegistry/ApplicationReviewRegistry.behavior.ts
@@ -101,42 +101,6 @@ export function shouldBehaveLikeApplicationReviewRegistry(): void {
   });
 
   describe("Auto assignment of Reviewers", function () {
-    it.only("check assignment", async function () {
-      const numOfReviewers = 10;
-      const numOfApplicants = 300;
-      const numOfReviewersPerApplication = 5;
-
-      const reviewers: Wallet[] = [];
-      for (let i = 0; i < numOfReviewers; ++i) reviewers.push(await randomWallet());
-
-      const applicants: Wallet[] = [];
-      for (let i = 0; i < numOfApplicants; ++i) {
-        applicants.push(await randomWallet());
-      }
-
-      this.workspaceRegistry.connect(this.signers.admin).updateWorkspaceMembers(
-        0,
-        reviewers.map(r => r.address),
-        Array(numOfReviewers).fill(1),
-        Array(numOfReviewers).fill(true),
-        Array(numOfReviewers).fill(""),
-      );
-
-      for (let i = 0; i < numOfApplicants; ++i) {
-        await this.applicationRegistry
-          .connect(applicants[i])
-          .submitApplication(this.grant.address, 0, "dummyApplicationIpfsHash", "1");
-      }
-
-      await this.applicationReviewRegistry.connect(this.signers.admin).setRubricsAndEnableAutoAssign(
-        0,
-        this.grant.address,
-        reviewers.map(r => r.address),
-        numOfReviewersPerApplication,
-        "Rubrics IPFS Hash",
-      );
-    });
-
     it("admin should be able to enable auto assigning of reviewers when one application is there", async function () {
       await this.workspaceRegistry.connect(this.signers.admin).updateWorkspaceMembers(
         0,
@@ -151,7 +115,6 @@ export function shouldBehaveLikeApplicationReviewRegistry(): void {
         0,
         this.grant.address,
         this.signers.autoAssignReviewers.map((autoAssignReviewer: SignerWithAddress) => autoAssignReviewer.address),
-        this.signers.autoAssignReviewers.map(() => true),
         numOfReviewersPerApplication,
         "dummyIPFSHash",
       );
@@ -185,7 +148,6 @@ export function shouldBehaveLikeApplicationReviewRegistry(): void {
         0,
         this.grant.address,
         this.signers.autoAssignReviewers.map((autoAssignReviewer: SignerWithAddress) => autoAssignReviewer.address),
-        this.signers.autoAssignReviewers.map(() => true),
         numOfReviewersPerApplication,
         "dummyIPFSHash",
       );
@@ -235,7 +197,6 @@ export function shouldBehaveLikeApplicationReviewRegistry(): void {
         0,
         this.grant.address,
         this.signers.autoAssignReviewers.map((autoAssignReviewer: SignerWithAddress) => autoAssignReviewer.address),
-        this.signers.autoAssignReviewers.map(() => true),
         numOfReviewersPerApplication,
         "dummyIPFSHash",
       );
@@ -266,6 +227,42 @@ export function shouldBehaveLikeApplicationReviewRegistry(): void {
           this.signers.autoAssignReviewers.length,
       );
       expect(areEqualDistributions(distribution, distributionFromContract)).to.equals(true);
+    });
+
+    it("stress test - reviewer assignment", async function () {
+      const numOfReviewers = 10;
+      const numOfApplicants = 300;
+      const numOfReviewersPerApplication = 5;
+
+      const reviewers: Wallet[] = [];
+      for (let i = 0; i < numOfReviewers; ++i) reviewers.push(await randomWallet());
+
+      const applicants: Wallet[] = [];
+      for (let i = 0; i < numOfApplicants; ++i) {
+        applicants.push(await randomWallet());
+      }
+
+      this.workspaceRegistry.connect(this.signers.admin).updateWorkspaceMembers(
+        0,
+        reviewers.map(r => r.address),
+        Array(numOfReviewers).fill(1),
+        Array(numOfReviewers).fill(true),
+        Array(numOfReviewers).fill(""),
+      );
+
+      for (let i = 0; i < numOfApplicants; ++i) {
+        await this.applicationRegistry
+          .connect(applicants[i])
+          .submitApplication(this.grant.address, 0, "dummyApplicationIpfsHash", "1");
+      }
+
+      await this.applicationReviewRegistry.connect(this.signers.admin).setRubricsAndEnableAutoAssign(
+        0,
+        this.grant.address,
+        reviewers.map(r => r.address),
+        numOfReviewersPerApplication,
+        "Rubrics IPFS Hash",
+      );
     });
   });
 
@@ -495,20 +492,25 @@ export function shouldBehaveLikeApplicationReviewRegistry(): void {
       const reviewRegistry = this.applicationReviewRegistry as ApplicationReviewRegistry;
       const migratedWalletAddress = randomEthAddress();
 
+      await this.workspaceRegistry.connect(admin).updateWorkspaceMembers(
+        0,
+        reviewers.map(r => r.address),
+        reviewers.map(() => 1),
+        reviewers.map(() => true),
+        reviewers.map(() => ""),
+      );
+
       // auto assign enabled to verify migration there happens correctly as well
       const tx0 = await reviewRegistry.setRubricsAndEnableAutoAssign(
         0,
         this.grant.address,
         reviewers.map(r => r.address),
-        reviewers.map(() => true),
         1,
         "dummyRubricsIpfsHash",
       );
       await tx0.wait();
 
       for (const reviewer of reviewers) {
-        await this.workspaceRegistry.connect(admin).updateWorkspaceMembers(0, [reviewer.address], [1], [true], [""]);
-
         await reviewRegistry.connect(admin).assignReviewers(0, 0, this.grant.address, [reviewer.address], [true]);
       }
       // should migrate the first reviewer

--- a/test/applicationReviewRegistry/ApplicationReviewRegistry.behavior.ts
+++ b/test/applicationReviewRegistry/ApplicationReviewRegistry.behavior.ts
@@ -180,13 +180,13 @@ export function shouldBehaveLikeApplicationReviewRegistry(): void {
     it("reviewer should be auto assigned to all existing applications", async function () {
       await this.workspaceRegistry.connect(this.signers.admin).updateWorkspaceMembers(
         0,
-        this.signers.autoAssignReviewers.map((autoAssignReviewer: SignerWithAddress) => autoAssignReviewer.address),
+        this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
         this.signers.autoAssignReviewers.map(() => 1),
         this.signers.autoAssignReviewers.map(() => true),
         this.signers.autoAssignReviewers.map(() => ""),
       );
 
-      this.signers.randomApplicants.map(async (applicant: SignerWithAddress) => {
+      this.signers.randomApplicants.map(async applicant => {
         await this.applicationRegistry
           .connect(applicant)
           .submitApplication(this.grant.address, 0, "dummyApplicationIpfsHash", "1");
@@ -196,7 +196,7 @@ export function shouldBehaveLikeApplicationReviewRegistry(): void {
       await this.applicationReviewRegistry.connect(this.signers.admin).setRubricsAndEnableAutoAssign(
         0,
         this.grant.address,
-        this.signers.autoAssignReviewers.map((autoAssignReviewer: SignerWithAddress) => autoAssignReviewer.address),
+        this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
         numOfReviewersPerApplication,
         "dummyIPFSHash",
       );
@@ -227,6 +227,490 @@ export function shouldBehaveLikeApplicationReviewRegistry(): void {
           this.signers.autoAssignReviewers.length,
       );
       expect(areEqualDistributions(distribution, distributionFromContract)).to.equals(true);
+    });
+
+    it("non admin cannot enable auto assignment", async function () {
+      await this.workspaceRegistry.connect(this.signers.admin).updateWorkspaceMembers(
+        0,
+        this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        this.signers.autoAssignReviewers.map(() => 1),
+        this.signers.autoAssignReviewers.map(() => true),
+        this.signers.autoAssignReviewers.map(() => ""),
+      );
+
+      this.signers.randomApplicants.map(async applicant => {
+        await this.applicationRegistry
+          .connect(applicant)
+          .submitApplication(this.grant.address, 0, "dummyApplicationIpfsHash", "1");
+      });
+
+      const numOfReviewersPerApplication = 4;
+      await expect(
+        this.applicationReviewRegistry.connect(this.signers.nonAdmin).setRubricsAndEnableAutoAssign(
+          0,
+          this.grant.address,
+          this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+          numOfReviewersPerApplication,
+          "dummyIPFSHash",
+        ),
+      ).to.be.revertedWith("Unauthorised: Not an admin nor grantFactory");
+    });
+
+    it("auto assignment won't be enabled if not enough reviewers selected", async function () {
+      await this.workspaceRegistry.connect(this.signers.admin).updateWorkspaceMembers(
+        0,
+        this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        this.signers.autoAssignReviewers.map(() => 1),
+        this.signers.autoAssignReviewers.map(() => true),
+        this.signers.autoAssignReviewers.map(() => ""),
+      );
+
+      this.signers.randomApplicants.map(async applicant => {
+        await this.applicationRegistry
+          .connect(applicant)
+          .submitApplication(this.grant.address, 0, "dummyApplicationIpfsHash", "1");
+      });
+
+      const numOfReviewersPerApplication = 4;
+      await expect(
+        this.applicationReviewRegistry.connect(this.signers.admin).setRubricsAndEnableAutoAssign(
+          0,
+          this.grant.address,
+          this.signers.autoAssignReviewers
+            .slice(0, numOfReviewersPerApplication - 1)
+            .map(autoAssignReviewer => autoAssignReviewer.address),
+          numOfReviewersPerApplication,
+          "dummyIPFSHash",
+        ),
+      ).to.be.revertedWith("AutoAssignReviewers: Not enough reviewers selected");
+    });
+
+    it("cannot enable auto assignment twice", async function () {
+      await this.workspaceRegistry.connect(this.signers.admin).updateWorkspaceMembers(
+        0,
+        this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        this.signers.autoAssignReviewers.map(() => 1),
+        this.signers.autoAssignReviewers.map(() => true),
+        this.signers.autoAssignReviewers.map(() => ""),
+      );
+
+      this.signers.randomApplicants.map(async applicant => {
+        await this.applicationRegistry
+          .connect(applicant)
+          .submitApplication(this.grant.address, 0, "dummyApplicationIpfsHash", "1");
+      });
+
+      const numOfReviewersPerApplication = 4;
+
+      await this.applicationReviewRegistry.connect(this.signers.admin).setRubricsAndEnableAutoAssign(
+        0,
+        this.grant.address,
+        this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        numOfReviewersPerApplication,
+        "dummyIPFSHash",
+      );
+
+      await expect(
+        this.applicationReviewRegistry.connect(this.signers.admin).setRubricsAndEnableAutoAssign(
+          0,
+          this.grant.address,
+          this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+          numOfReviewersPerApplication,
+          "dummyIPFSHash",
+        ),
+      ).to.be.revertedWith("AutoAssignReviewers: Auto assignment already enabled");
+    });
+
+    it("auto assignment won't be enabled if num of reviewers per application is negative", async function () {
+      await this.workspaceRegistry.connect(this.signers.admin).updateWorkspaceMembers(
+        0,
+        this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        this.signers.autoAssignReviewers.map(() => 1),
+        this.signers.autoAssignReviewers.map(() => true),
+        this.signers.autoAssignReviewers.map(() => ""),
+      );
+
+      this.signers.randomApplicants.map(async applicant => {
+        await this.applicationRegistry
+          .connect(applicant)
+          .submitApplication(this.grant.address, 0, "dummyApplicationIpfsHash", "1");
+      });
+
+      const numOfReviewersPerApplication = 0;
+      await expect(
+        this.applicationReviewRegistry.connect(this.signers.admin).setRubricsAndEnableAutoAssign(
+          0,
+          this.grant.address,
+          this.signers.autoAssignReviewers
+            .slice(0, numOfReviewersPerApplication - 1)
+            .map(autoAssignReviewer => autoAssignReviewer.address),
+          numOfReviewersPerApplication,
+          "dummyIPFSHash",
+        ),
+      ).to.be.revertedWith("AutoAssignReviewers: Reviewers per application must be positive");
+    });
+
+    it("auto assignment won't be enabled if the reviewers are not a reviewer in the workspace", async function () {
+      this.signers.randomApplicants.map(async applicant => {
+        await this.applicationRegistry
+          .connect(applicant)
+          .submitApplication(this.grant.address, 0, "dummyApplicationIpfsHash", "1");
+      });
+
+      const numOfReviewersPerApplication = 4;
+
+      await expect(
+        this.applicationReviewRegistry.connect(this.signers.admin).setRubricsAndEnableAutoAssign(
+          0,
+          this.grant.address,
+          this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+          numOfReviewersPerApplication,
+          "dummyIPFSHash",
+        ),
+      ).to.be.revertedWith("AutoAssignReviewers: Not a reviewer");
+    });
+
+    it("assign reviewers only to submitted applications", async function () {
+      await this.workspaceRegistry.connect(this.signers.admin).updateWorkspaceMembers(
+        0,
+        this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        this.signers.autoAssignReviewers.map(() => 1),
+        this.signers.autoAssignReviewers.map(() => true),
+        this.signers.autoAssignReviewers.map(() => ""),
+      );
+
+      this.signers.randomApplicants.map(async applicant => {
+        await this.applicationRegistry
+          .connect(applicant)
+          .submitApplication(this.grant.address, 0, "dummyApplicationIpfsHash", "1");
+      });
+
+      await this.applicationRegistry.connect(this.signers.admin).updateApplicationState(0, 0, 3, "rejectionIpfsHash");
+
+      const numOfReviewersPerApplication = 4;
+      await this.applicationReviewRegistry.connect(this.signers.admin).setRubricsAndEnableAutoAssign(
+        0,
+        this.grant.address,
+        this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        numOfReviewersPerApplication,
+        "dummyIPFSHash",
+      );
+
+      const distribution = generateAssignment(
+        this.signers.randomApplicants.length,
+        this.signers.autoAssignReviewers.length,
+        numOfReviewersPerApplication,
+      );
+
+      const distributionFromContract: number[] = [];
+      for (const autoAssignReviewer of this.signers.autoAssignReviewers) {
+        distributionFromContract.push(
+          (
+            await this.applicationReviewRegistry.reviewerAssignmentCounts(
+              this.grant.address,
+              autoAssignReviewer.address,
+            )
+          ).toNumber(),
+        );
+      }
+
+      expect(distribution).eqls(distributionFromContract);
+    });
+
+    it("cannot update auto assignment config to a auto-assignment-disabled grant", async function () {
+      await this.workspaceRegistry.connect(this.signers.admin).updateWorkspaceMembers(
+        0,
+        this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        this.signers.autoAssignReviewers.map(() => 1),
+        this.signers.autoAssignReviewers.map(() => true),
+        this.signers.autoAssignReviewers.map(() => ""),
+      );
+
+      this.signers.randomApplicants.map(async applicant => {
+        await this.applicationRegistry
+          .connect(applicant)
+          .submitApplication(this.grant.address, 0, "dummyApplicationIpfsHash", "1");
+      });
+
+      const numOfReviewersPerApplication = 4;
+      await expect(
+        this.applicationReviewRegistry.connect(this.signers.admin).updateAutoAssignmentOfReviewers(
+          0,
+          this.grant.address,
+          this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+          numOfReviewersPerApplication,
+        ),
+      ).to.be.revertedWith("AutoAssignReviewers: Auto assignment not enabled");
+    });
+
+    it("non admin cannot update auto assignment config", async function () {
+      await this.workspaceRegistry.connect(this.signers.admin).updateWorkspaceMembers(
+        0,
+        this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        this.signers.autoAssignReviewers.map(() => 1),
+        this.signers.autoAssignReviewers.map(() => true),
+        this.signers.autoAssignReviewers.map(() => ""),
+      );
+
+      this.signers.randomApplicants.map(async applicant => {
+        await this.applicationRegistry
+          .connect(applicant)
+          .submitApplication(this.grant.address, 0, "dummyApplicationIpfsHash", "1");
+      });
+
+      const numOfReviewersPerApplication = 4;
+      await this.applicationReviewRegistry.connect(this.signers.admin).setRubricsAndEnableAutoAssign(
+        0,
+        this.grant.address,
+        this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        numOfReviewersPerApplication,
+        "dummyIpfsHash",
+      );
+
+      await expect(
+        this.applicationReviewRegistry.connect(this.signers.nonAdmin).updateAutoAssignmentOfReviewers(
+          0,
+          this.grant.address,
+          this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+          numOfReviewersPerApplication,
+        ),
+      ).to.be.revertedWith("Unauthorised: Not an admin nor grantFactory");
+    });
+
+    it("admin should be able to update auto assignment config", async function () {
+      await this.workspaceRegistry.connect(this.signers.admin).updateWorkspaceMembers(
+        0,
+        this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        this.signers.autoAssignReviewers.map(() => 1),
+        this.signers.autoAssignReviewers.map(() => true),
+        this.signers.autoAssignReviewers.map(() => ""),
+      );
+
+      this.signers.randomApplicants.map(async applicant => {
+        await this.applicationRegistry
+          .connect(applicant)
+          .submitApplication(this.grant.address, 0, "dummyApplicationIpfsHash", "1");
+      });
+
+      const numOfReviewersPerApplication = 4;
+      await this.applicationReviewRegistry.connect(this.signers.admin).setRubricsAndEnableAutoAssign(
+        0,
+        this.grant.address,
+        this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        numOfReviewersPerApplication,
+        "dummyIpfsHash",
+      );
+
+      await this.applicationReviewRegistry.connect(this.signers.admin).updateAutoAssignmentOfReviewers(
+        0,
+        this.grant.address,
+        this.signers.autoAssignReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        numOfReviewersPerApplication,
+      );
+    });
+
+    it("should assign updated reviewers to new applications", async function () {
+      const oldReviewerCount = 10;
+      const newReviewerCount = 20;
+
+      const oldReviewers: Wallet[] = [];
+      for (let i = 0; i < oldReviewerCount; ++i) {
+        oldReviewers.push(await randomWallet());
+      }
+      const applicantList1 = this.signers.randomApplicants.slice(
+        0,
+        Math.floor(this.signers.randomApplicants.length / 2),
+      );
+
+      await this.workspaceRegistry.connect(this.signers.admin).updateWorkspaceMembers(
+        0,
+        oldReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        oldReviewers.map(() => 1),
+        oldReviewers.map(() => true),
+        oldReviewers.map(() => ""),
+      );
+
+      applicantList1.map(async applicant => {
+        await this.applicationRegistry
+          .connect(applicant)
+          .submitApplication(this.grant.address, 0, "dummyApplicationIpfsHash", "1");
+      });
+
+      const numOfReviewersPerApplication = 4;
+      await this.applicationReviewRegistry.connect(this.signers.admin).setRubricsAndEnableAutoAssign(
+        0,
+        this.grant.address,
+        oldReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        numOfReviewersPerApplication,
+        "dummyIpfsHash",
+      );
+
+      const oldDistributionFromContract1: number[] = [];
+      for (const autoAssignReviewer of oldReviewers) {
+        oldDistributionFromContract1.push(
+          (
+            await this.applicationReviewRegistry.reviewerAssignmentCounts(
+              this.grant.address,
+              autoAssignReviewer.address,
+            )
+          ).toNumber(),
+        );
+      }
+
+      const newReviewers: Wallet[] = [];
+      for (let i = 0; i < newReviewerCount; ++i) {
+        newReviewers.push(await randomWallet());
+      }
+      const applicantList2 = this.signers.randomApplicants.slice(Math.floor(this.signers.randomApplicants.length / 2));
+
+      await this.workspaceRegistry.connect(this.signers.admin).updateWorkspaceMembers(
+        0,
+        newReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        newReviewers.map(() => 1),
+        newReviewers.map(() => true),
+        newReviewers.map(() => ""),
+      );
+
+      await this.applicationReviewRegistry.connect(this.signers.admin).updateAutoAssignmentOfReviewers(
+        0,
+        this.grant.address,
+        newReviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        numOfReviewersPerApplication,
+      );
+
+      applicantList2.map(async applicant => {
+        await this.applicationRegistry
+          .connect(applicant)
+          .submitApplication(this.grant.address, 0, "dummyApplicationIpfsHash", "1");
+      });
+
+      const oldDistributionFromContract2: number[] = [];
+      for (const autoAssignReviewer of oldReviewers) {
+        oldDistributionFromContract2.push(
+          (
+            await this.applicationReviewRegistry.reviewerAssignmentCounts(
+              this.grant.address,
+              autoAssignReviewer.address,
+            )
+          ).toNumber(),
+        );
+      }
+
+      const newDistributionFromContract: number[] = [];
+      for (const autoAssignReviewer of newReviewers) {
+        newDistributionFromContract.push(
+          (
+            await this.applicationReviewRegistry.reviewerAssignmentCounts(
+              this.grant.address,
+              autoAssignReviewer.address,
+            )
+          ).toNumber(),
+        );
+      }
+
+      const distribution = generateAssignment(applicantList2.length, newReviewerCount, numOfReviewersPerApplication);
+
+      expect(oldDistributionFromContract1).eqls(oldDistributionFromContract2);
+      expect(distribution).eqls(newDistributionFromContract);
+    });
+
+    it.only("should assign updated num of reviewers to new applications", async function () {
+      const reviewerCount = 10;
+
+      const reviewers: Wallet[] = [];
+      for (let i = 0; i < reviewerCount; ++i) {
+        reviewers.push(await randomWallet());
+      }
+      const applicantList1 = this.signers.randomApplicants.slice(
+        0,
+        Math.floor(this.signers.randomApplicants.length / 2),
+      );
+
+      await this.workspaceRegistry.connect(this.signers.admin).updateWorkspaceMembers(
+        0,
+        reviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        reviewers.map(() => 1),
+        reviewers.map(() => true),
+        reviewers.map(() => ""),
+      );
+
+      applicantList1.map(async applicant => {
+        await this.applicationRegistry
+          .connect(applicant)
+          .submitApplication(this.grant.address, 0, "dummyApplicationIpfsHash", "1");
+      });
+
+      const oldNumOfReviewersPerApplication = 4;
+      await this.applicationReviewRegistry.connect(this.signers.admin).setRubricsAndEnableAutoAssign(
+        0,
+        this.grant.address,
+        reviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        oldNumOfReviewersPerApplication,
+        "dummyIpfsHash",
+      );
+
+      const oldDistributionFromContract: number[] = [];
+      for (const autoAssignReviewer of reviewers) {
+        oldDistributionFromContract.push(
+          (
+            await this.applicationReviewRegistry.reviewerAssignmentCounts(
+              this.grant.address,
+              autoAssignReviewer.address,
+            )
+          ).toNumber(),
+        );
+      }
+      const distribution1 = generateAssignment(
+        applicantList1.length + 1,
+        reviewerCount,
+        oldNumOfReviewersPerApplication,
+      );
+
+      const applicantList2 = this.signers.randomApplicants.slice(Math.floor(this.signers.randomApplicants.length / 2));
+
+      const newNumOfReviewersPerApplication = 5;
+      await this.applicationReviewRegistry.connect(this.signers.admin).updateAutoAssignmentOfReviewers(
+        0,
+        this.grant.address,
+        reviewers.map(autoAssignReviewer => autoAssignReviewer.address),
+        newNumOfReviewersPerApplication,
+      );
+
+      for (const applicant of applicantList2) {
+        await this.applicationRegistry
+          .connect(applicant)
+          .submitApplication(this.grant.address, 0, "dummyApplicationIpfsHash", "1");
+      }
+
+      const newDistributionFromContract: number[] = [];
+      for (const autoAssignReviewer of reviewers) {
+        newDistributionFromContract.push(
+          (
+            await this.applicationReviewRegistry.reviewerAssignmentCounts(
+              this.grant.address,
+              autoAssignReviewer.address,
+            )
+          ).toNumber(),
+        );
+      }
+
+      const distribution2 = generateAssignment(applicantList2.length, reviewerCount, newNumOfReviewersPerApplication);
+      const sum: number[] = [];
+      for (let i = 0; i < reviewerCount; ++i) sum.push(distribution1[i] + distribution2[i]);
+
+      expect(sum).eqls(newDistributionFromContract);
+    });
+
+    it("cannot disable auto assignment to a grant where it is not enabled", async function () {
+      await expect(
+        this.applicationReviewRegistry.connect(this.signers.admin).disableAutoAssignment(0, this.grant.address),
+      ).revertedWith("AutoAssignReviewers: Auto assignment not enabled");
+    });
+
+    it("only admin can disable auto assignment", async function () {
+      await expect(
+        this.applicationReviewRegistry.connect(this.signers.nonAdmin).disableAutoAssignment(0, this.grant.address),
+      ).revertedWith("Unauthorised: Not an admin nor grantFactory");
     });
 
     it("stress test - reviewer assignment", async function () {


### PR DESCRIPTION
### Some comments about auto assigning of reviewers
**Initial implementation:**
1. For auto assigning reviewers to applications, maintain a list of reviewers `R` for a grant `G`, the number of reviewers to be assigned per application as `n` and the index of the last assigned reviewer in `R` as `i`, such that `r(G) = (R, n, i)`

2. When a new application `a` would come in, the first `n` reviewers from `R` are assigned to `a` and `i` is updated as `(i + n) % length(R)`

3. So, at the time of initially enabling auto assignment, step 2, had to be called for every application that was already present in the grant.
4. And for every new application, step 2 is called.

_Problem:_ The above approach resulted in the function exceeding the allowed block gas limit for number of existing applications > 120 (Empirical finding - was unable to assign reviewers for a grant on Polygon Mainnet with 200+ existing applications)

**Failed approach 1**
1. Instead of doing the assignment computation on-chain, an alternative was to send an assignment (an array `A` such that `A[i]` corresponds to an array `R[i]` that denotes the reviewers that would be assigned to application with id `A[i]`.
2. The computation cost of verifying if the assignment was correct and valid or not resulted in the block gas limit exceeding issue much faster than the already present approach.

**Failed approach 2 (Brute force - Merge sort)**
1. Sort the array `R` every time based on the number of applications assigned to them already.
2. Filter out the first `n` from `R` and assign it to an application
3. Do the above two steps for all existing applications
4. For new applications, follow step 2 of Initial Implementation
5. The problem was the same. Sorting on-chain is very computation intensive.

**Failed approach 3 (Maintaining a min-heap)**
1. Maintain a binary min heap that stores the reviewer with the minimum number of applications assigned as the root. So, extracting the first `n` from the min-heap, while executing `heapify` after each extraction, should get us the list of least busy reviewers.
2. However, the above approach again involved a complexity of `O(log(len(R))` for each of the applications, which ended up being too gas-intensive!

**Implemented latest approach**
1. Follow step 2 of Initial Implementation for all new applications that come in
2. For already existing applications `A` in the `Submitted` state, do the following for `A[i]`:
i. From the list of reviewers `R`, take the first `n` reviewers and assign them to `A[i]`
ii. Do not store the index of the last assigned reviewer nor have the need to traverse `R` every time. 
3. Once reviewers are assigned to all the existing applications, store the index.

### Extra additions in this PR
1. The ability to edit the list of reviewers that would be auto assigned (previously there was no way to edit the list of reviewers once set)
2. The ability to edit the number of reviewers to be assigned per application